### PR TITLE
pyload.org domain expired

### DIFF
--- a/recipes-connectivity/pyload/pyload.bb
+++ b/recipes-connectivity/pyload/pyload.bb
@@ -25,7 +25,7 @@ PR = "r1"
 
 inherit update-rc.d
 
-SRC_URI = "http://download.pyload.org/pyload-src-v${PV}.zip \
+SRC_URI = "https://github.com/pyload/pyload/releases/download/v${PV}/pyload-src-v${PV}.zip \
   file://pyload.init \
   file://pyload.tar.gz.defaults"
 SRC_URI[md5sum] = "28876150af22999b6f539c8579d3b415"


### PR DESCRIPTION
reference https://github.com/pyload/pyload.github.io/issues/1
